### PR TITLE
NamedRouteCollection’s routes is private in Rails 5

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ QUnit::Rails::Engine.routes.draw do
 end
 
 Rails.application.routes.draw do
-  unless Rails.application.routes.named_routes.routes[:q_unit_rails]
+  unless Rails.application.routes.named_routes.key?(:q_unit_rails)
     mount QUnit::Rails::Engine => "/qunit"
   end
 end


### PR DESCRIPTION
After https://github.com/rails/rails/commit/7187339854d8454fdb3338b3041f89c6ce7e1e41, `routes` instance variable will not be accessible anymore. Changing that to using `key?` so this gem can support Rails 5.